### PR TITLE
Add sha256 verification to welcome processing.

### DIFF
--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -186,6 +186,8 @@ class Verification:
                           for name in allowed_names]
             md5_allow = [hashlib.md5(name.encode('utf-8')).hexdigest()
                          for name in allowed_names]
+            sha256_allow = [hashlib.sha256(name.encode('utf-8')).hexdigest()
+                         for name in allowed_names]
             sha1_close = [hashlib.sha1(name.encode('utf-8')).hexdigest()
                           for name in close_names]
 
@@ -196,6 +198,8 @@ class Verification:
             elif any(close in mcl for close in sha1_close):
                 await chan.send(f"{message.author.mention} :no_entry: Close, but incorrect. You got the process right, but you're not doing it on your name and discriminator properly. Please re-read the rules carefully and look up any terms you are not familiar with.")
             elif any(allow in mcl for allow in md5_allow):
+                await chan.send(f"{message.author.mention} :no_entry: Close, but incorrect. You're processing your name and discriminator properly, but you're not using the right process. Please re-read the rules carefully and look up any terms you are not familiar with.")
+            elif any(allow in mcl for allow in sha256_allow):
                 await chan.send(f"{message.author.mention} :no_entry: Close, but incorrect. You're processing your name and discriminator properly, but you're not using the right process. Please re-read the rules carefully and look up any terms you are not familiar with.")
             elif full_name in message.content or str(member.id) in message.content or member.name in message.content or discrim in message.content:
                 await chan.send(f"{message.author.mention} :no_entry: Incorrect. You need to do something *specific* with your name and discriminator instead of just posting it. Please re-read the rules carefully and look up any terms you are not familiar with.")


### PR DESCRIPTION
Works the same as the md5 "not using the right process." codepath.
Could surely be optimized to be checked alongside md5 and return the same message.