### PR TITLE
This implements the latest breaking changes to cogs from d.py rewrite.

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -1,12 +1,13 @@
 import discord
 from discord.ext import commands
+from discord.ext.commands import Cog
 import traceback
 import inspect
 import re
 from helpers.checks import check_if_bot_manager
 
 
-class Admin:
+class Admin(Cog):
     def __init__(self, bot):
         self.bot = bot
         self.last_eval_result = None

--- a/cogs/basic.py
+++ b/cogs/basic.py
@@ -2,9 +2,9 @@ import time
 import config
 import discord
 from discord.ext import commands
+from discord.ext.commands import Cog
 
-
-class Basic:
+class Basic(Cog):
     def __init__(self, bot):
         self.bot = bot
 

--- a/cogs/common.py
+++ b/cogs/common.py
@@ -5,9 +5,9 @@ import humanize
 import time
 import math
 import parsedatetime
+from discord.ext.commands import Cog
 
-
-class Common:
+class Common(Cog):
     def __init__(self, bot):
         self.bot = bot
 

--- a/cogs/err.py
+++ b/cogs/err.py
@@ -2,10 +2,10 @@ import re
 import discord
 
 from discord.ext import commands
+from discord.ext.commands import Cog
 from helpers.errcodes import *
 
-
-class Err:
+class Err(Cog):
     """Everything related to Nintendo 3DS, Wii U and Switch error codes"""
 
     def __init__(self, bot):

--- a/cogs/legacy.py
+++ b/cogs/legacy.py
@@ -1,7 +1,7 @@
 from discord.ext import commands
+from discord.ext.commands import Cog
 
-
-class Legacy:
+class Legacy(Cog):
     def __init__(self, bot):
         self.bot = bot
 

--- a/cogs/links.py
+++ b/cogs/links.py
@@ -1,9 +1,9 @@
 import discord
 import config
 from discord.ext import commands
+from discord.ext.commands import Cog
 
-
-class Links:
+class Links(Cog):
     """
     Commands for easily linking to projects.
     """

--- a/cogs/lockdown.py
+++ b/cogs/lockdown.py
@@ -1,10 +1,10 @@
 from discord.ext import commands
+from discord.ext.commands import Cog
 import config
 import discord
 from helpers.checks import check_if_staff
 
-
-class Lockdown:
+class Lockdown(Cog):
     def __init__(self, bot):
         self.bot = bot
 

--- a/cogs/logs.py
+++ b/cogs/logs.py
@@ -1,11 +1,11 @@
 import discord
+from discord.ext.commands import Cog
 import json
 import re
 import config
 from helpers.restrictions import get_user_restrictions
 
-
-class Logs:
+class Logs(Cog):
     """
     Logs join and leave messages, bans and unbans, and member changes.
     """
@@ -21,6 +21,7 @@ class Logs:
                            "nsp", "xci", "nut", "doge", "cdnsp", "lithium"]
         self.ok_words = ["nspwn", "hblnsp", "exefs"]
 
+    @Cog.listener()
     async def on_member_join(self, member):
         await self.bot.wait_until_ready()
         log_channel = self.bot.get_channel(config.log_channel)
@@ -111,6 +112,7 @@ class Logs:
         spy_channel = self.bot.get_channel(config.spylog_channel)
         await spy_channel.send(msg)
 
+    @Cog.listener()
     async def on_message(self, message):
         await self.bot.wait_until_ready()
         if message.channel.id not in config.spy_channels:
@@ -118,6 +120,7 @@ class Logs:
 
         await self.do_spy(message)
 
+    @Cog.listener()
     async def on_message_edit(self, before, after):
         await self.bot.wait_until_ready()
         if after.channel.id not in config.spy_channels or after.author.bot:
@@ -143,6 +146,7 @@ class Logs:
 
         await log_channel.send(msg)
 
+    @Cog.listener()
     async def on_message_delete(self, message):
         await self.bot.wait_until_ready()
         if message.channel.id not in config.spy_channels or message.author.bot:
@@ -161,6 +165,7 @@ class Logs:
 
         await log_channel.send(msg)
 
+    @Cog.listener()
     async def on_member_remove(self, member):
         await self.bot.wait_until_ready()
         log_channel = self.bot.get_channel(config.log_channel)
@@ -169,6 +174,7 @@ class Logs:
               f"🏷 __User ID__: {member.id}"
         await log_channel.send(msg)
 
+    @Cog.listener()
     async def on_member_ban(self, guild, member):
         await self.bot.wait_until_ready()
         log_channel = self.bot.get_channel(config.modlog_channel)
@@ -177,6 +183,7 @@ class Logs:
               f"🏷 __User ID__: {member.id}"
         await log_channel.send(msg)
 
+    @Cog.listener()
     async def on_member_unban(self, guild, user):
         await self.bot.wait_until_ready()
         log_channel = self.bot.get_channel(config.modlog_channel)
@@ -194,6 +201,7 @@ class Logs:
         #             json.dump(timebans, f)
         await log_channel.send(msg)
 
+    @Cog.listener()
     async def on_member_update(self, member_before, member_after):
         await self.bot.wait_until_ready()
         msg = ""

--- a/cogs/meme.py
+++ b/cogs/meme.py
@@ -1,12 +1,13 @@
 import random
 import discord
 from discord.ext import commands
+from discord.ext.commands import Cog
 import math
 import platform
 from helpers.checks import check_if_staff_or_ot
 
 
-class Meme:
+class Meme(Cog):
     """
     Meme commands.
     """

--- a/cogs/mod.py
+++ b/cogs/mod.py
@@ -1,5 +1,6 @@
 import discord
 from discord.ext import commands
+from discord.ext.commands import Cog
 import config
 from helpers.checks import check_if_staff, check_if_bot_manager
 from helpers.userlogs import userlog
@@ -7,7 +8,7 @@ from helpers.restrictions import add_restriction, remove_restriction
 import io
 
 
-class Mod:
+class Mod(Cog):
     def __init__(self, bot):
         self.bot = bot
 

--- a/cogs/mod_note.py
+++ b/cogs/mod_note.py
@@ -1,10 +1,11 @@
 import discord
 from discord.ext import commands
+from discord.ext.commands import Cog
 from helpers.checks import check_if_staff
 from helpers.userlogs import userlog
 
 
-class ModNote:
+class ModNote(Cog):
     def __init__(self, bot):
         self.bot = bot
 

--- a/cogs/mod_reacts.py
+++ b/cogs/mod_reacts.py
@@ -1,11 +1,12 @@
 import asyncio
 import discord
 from discord.ext import commands
+from discord.ext.commands import Cog
 import config
 from helpers.checks import check_if_staff
 
 
-class ModReact:
+class ModReact(Cog):
     def __init__(self, bot):
         self.bot = bot
 

--- a/cogs/mod_timed.py
+++ b/cogs/mod_timed.py
@@ -2,13 +2,14 @@ import discord
 import config
 from datetime import datetime
 from discord.ext import commands
+from discord.ext.commands import Cog
 from helpers.checks import check_if_staff
 from helpers.robocronp import add_job
 from helpers.userlogs import userlog
 from helpers.restrictions import add_restriction
 
 
-class ModTimed:
+class ModTimed(Cog):
     def __init__(self, bot):
         self.bot = bot
 

--- a/cogs/mod_userlog.py
+++ b/cogs/mod_userlog.py
@@ -1,12 +1,13 @@
 import discord
 from discord.ext import commands
+from discord.ext.commands import Cog
 import config
 import json
 from helpers.checks import check_if_staff
 from helpers.userlogs import get_userlog, set_userlog, userlog_event_types
 
 
-class ModUserlog:
+class ModUserlog(Cog):
     def __init__(self, bot):
         self.bot = bot
 

--- a/cogs/remind.py
+++ b/cogs/remind.py
@@ -3,10 +3,11 @@ import asyncio
 import time
 from datetime import datetime
 from discord.ext import commands
+from discord.ext.commands import Cog
 from helpers.robocronp import add_job, get_crontab
 
 
-class Remind:
+class Remind(Cog):
     def __init__(self, bot):
         self.bot = bot
 

--- a/cogs/robocronp.py
+++ b/cogs/robocronp.py
@@ -4,12 +4,13 @@ import time
 import discord
 import traceback
 from discord.ext import commands
+from discord.ext.commands import Cog
 from helpers.robocronp import get_crontab, delete_job
 from helpers.restrictions import remove_restriction
 from helpers.checks import check_if_staff
 
 
-class Robocronp:
+class Robocronp(Cog):
     def __init__(self, bot):
         self.bot = bot
         bot.loop.create_task(self.minutely())

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -1,5 +1,6 @@
 import discord
 from discord.ext import commands
+from discord.ext.commands import Cog
 import asyncio
 import config
 import random
@@ -107,7 +108,7 @@ welcome_footer = (
 hidden_term_line = ' • When you have finished reading all of the rules, send a message in this channel that includes the SHA1 hash of your discord "name#discriminator" (for example, User#1234), and we\'ll grant you access to the other channels. You can find your "name#discriminator" (your username followed by a ‘#’ and four numbers) under the discord channel list.'
 
 
-class Verification:
+class Verification(Cog):
     def __init__(self, bot):
         self.bot = bot
 
@@ -225,6 +226,7 @@ class Verification:
                     no_text = "ugh, wrong, read the rules."
                 await chan.send(f"{message.author.mention} {no_text}")
 
+    @Cog.listener()
     async def on_message(self, message):
         if message.author.bot:
             return
@@ -235,6 +237,7 @@ class Verification:
             chan = self.bot.get_channel(message.channel)
             await chan.send("💢 I don't have permission to do this.")
 
+    @Cog.listener()
     async def on_message_edit(self, before, after):
         if after.author.bot:
             return


### PR DESCRIPTION
They're all syntax changes and renames. I've checked twice to make sure
I didn't miss any listeners or classes.

For future reference:
- Do `from discord.ext.commands import Cog` in all new cogs.
- Subclass the new class to Cog.
- New listeners should get the `@Cog.listener()` decorator.

Conveniently, there weren't any pre-execution methods that have been
renamed.