### PR TITLE
Remove `.guide` command.

### DIFF
--- a/robocop_ng/cogs/links.py
+++ b/robocop_ng/cogs/links.py
@@ -34,11 +34,6 @@ class Links(Cog):
             "if you're not actually trying to solve a problem."
         )
 
-    @commands.command(hidden=True, aliases=["guides", "link"])
-    async def guide(self, ctx):
-        """Link to the guides"""
-        await ctx.send(config.links_guide_text)
-
     @commands.command()
     async def source(self, ctx):
         """Gives link to source code."""

--- a/robocop_ng/config_template.py
+++ b/robocop_ng/config_template.py
@@ -175,18 +175,6 @@ suspect_ignored_words = [
     "jit's",
 ]
 
-# == For cogs.links ==
-links_guide_text = """**Generic starter guides:**
-Nintendo Homebrew's Guide: <https://nh-server.github.io/switch-guide/>
-
-**Specific guides:**
-Manually Updating/Downgrading (with HOS): <https://switch.homebrew.guide/usingcfw/manualupgrade>
-Manually Repairing/Downgrading (without HOS): <https://switch.homebrew.guide/usingcfw/manualchoiupgrade>
-How to set up a Homebrew development environment: <https://devkitpro.org/wiki/Getting_Started>
-Getting full RAM in homebrew without NSPs: As of Atmosphere 0.8.6, hold R while opening any game.
-Check if a switch is vulnerable to RCM through serial: <https://akdm.github.io/ssnc/checker/>
-"""
-
 # == For cogs.verification ==
 # ReSwitched verification system is rather unique.
 # You might want to reimplement it.


### PR DESCRIPTION
Outdated guides/links, (update, manual update, serial checker), and getting started guides made by Nintendo Homebrew, which ReSwitched does not recommend anymore (see: https://discord.com/channels/269333940928512010/539212260350885908/1490125383385874483) (main guide, update, manual update), leaving only title override instruction, and devkitpro setup, neither of which need a command.